### PR TITLE
✨ Combine next and yoga servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,7 @@
     ```bash
     yarn run db:up
     ```
-2.  Start the server:
-    ```bash
-    yarn run server
-    ```
-3.  Start the application:
+2.  Start the application:
     ```bash
     yarn start
     ```
@@ -39,24 +35,16 @@ When developing, you can either develop with persistent data from your local dat
     ```bash
     yarn run db:up
     ```
-2.  Start the server:
-    ```bash
-    yarn run server
-    ```
-3.  Start the client in dev mode:
+2.  Start the application in dev mode:
     ```bash
     yarn run dev
     ```
 
 ### Using mocked data
 
-1.  Start the server in dev mode:
+1.  Start the application in dev mock mode:
     ```bash
-    yarn run server:dev
-    ```
-2.  Start the client in dev mode:
-    ```bash
-    yarn run dev
+    yarn run dev:mock
     ```
 
 ## Mocking data

--- a/index.js
+++ b/index.js
@@ -1,0 +1,41 @@
+const next = require('next')
+const server = require('./server/src')
+
+const port = parseInt(process.env.PORT, 10) || 3000
+const dev = process.env.NODE_ENV !== 'production'
+const app = next({ dev })
+const handle = app.getRequestHandler()
+
+app.prepare().then(() => {
+  server.express.get('*', (req, res, next) => {
+    if (req.path.match(/^\/playground|graphql|subscriptions\/?.*/)) {
+      next()
+    } else {
+      return handle(req, res)
+    }
+  })
+
+  server.start(
+    {
+      port,
+      endpoint: '/graphql',
+      subscriptions: '/subscriptions',
+      playground: dev && '/playground'
+    },
+    ({ endpoint, subscriptions, playground }) => {
+      endpoint &&
+        console.log(
+          `> GraphQL server is running on http://localhost:${port}${endpoint}`
+        )
+      subscriptions &&
+        console.log(
+          `> GraphQL subscriptions is running on http://localhost:${port}${subscriptions}`
+        )
+      playground &&
+        console.log(
+          `> GraphQL playground is running on http://localhost:${port}${playground}`
+        )
+      console.log(`> Ready on http://localhost:${port}`)
+    }
+  )
+})

--- a/index.js
+++ b/index.js
@@ -1,4 +1,6 @@
 const next = require('next')
+const compression = require('compression')
+
 const server = require('./server/src')
 
 const port = parseInt(process.env.PORT, 10) || 3000
@@ -7,6 +9,8 @@ const app = next({ dev })
 const handle = app.getRequestHandler()
 
 app.prepare().then(() => {
+  server.express.use(compression())
+
   server.express.get('*', (req, res, next) => {
     if (req.path.match(/^\/(playground|graphql|subscriptions)((?!.)|\/).*/)) {
       next()

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ const handle = app.getRequestHandler()
 
 app.prepare().then(() => {
   server.express.get('*', (req, res, next) => {
-    if (req.path.match(/^\/playground|graphql|subscriptions\/?.*/)) {
+    if (req.path.match(/^\/(playground|graphql|subscriptions)((?!.)|\/).*/)) {
       next()
     } else {
       return handle(req, res)

--- a/lib/init-apollo.js
+++ b/lib/init-apollo.js
@@ -1,6 +1,8 @@
 import { ApolloClient, HttpLink, InMemoryCache } from 'apollo-boost'
 import fetch from 'isomorphic-unfetch'
 
+const port = parseInt(process.env.PORT, 10) || 3000
+
 let apolloClient = null
 
 // Polyfill fetch() on the server (used by apollo-client)
@@ -13,7 +15,7 @@ function create(initialState) {
     connectToDevTools: process.browser,
     ssrMode: !process.browser, // Disables forceFetch on the server (so queries are only run once)
     link: new HttpLink({
-      uri: 'http://localhost:4000', // Server URL (must be absolute)
+      uri: `http://localhost:${port}/graphql`, // Server URL (must be absolute)
       credentials: 'same-origin' // Additional fetch() options like `credentials` or `headers`
     }),
     cache: new InMemoryCache().restore(initialState || {})

--- a/package.json
+++ b/package.json
@@ -10,13 +10,14 @@
     "prisma:deploy": "cd server/database && prisma deploy",
     "dev": "yarn run prisma:deploy && node index.js",
     "dev:mock": "MOCKS=true node index.js",
-    "build": "next build",
-    "start": "NODE_ENV=production yarn run prisma:deploy && node index.js",
+    "build": "NODE_ENV=production next build",
+    "start": "yarn run prisma:deploy && NODE_ENV=production node index.js",
     "prettier": "prettier --write \"**/*.{js,md,graphql,json}\"",
     "precommit": "precise-commits"
   },
   "dependencies": {
     "apollo-boost": "^0.1.6",
+    "compression": "^1.7.2",
     "graphql-tag": "^2.9.2",
     "graphql-yoga": "^1.13.1",
     "isomorphic-unfetch": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -7,11 +7,11 @@
   "license": "MIT",
   "scripts": {
     "db:up": "cd server/database && docker-compose up",
-    "server": "cd server/database && prisma deploy && cd ../.. && node ./server/src",
-    "server:dev": "MOCKS=true node ./server/src",
-    "dev": "next",
+    "prisma:deploy": "cd server/database && prisma deploy",
+    "dev": "yarn run prisma:deploy && node index.js",
+    "dev:mock": "MOCKS=true node index.js",
     "build": "next build",
-    "start": "next start",
+    "start": "NODE_ENV=production yarn run prisma:deploy && node index.js",
     "prettier": "prettier --write \"**/*.{js,md,graphql,json}\"",
     "precommit": "precise-commits"
   },

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -85,6 +85,5 @@ const server = new GraphQLServer({
     })
   })
 })
-server.start(() =>
-  console.log(`GraphQL server is running on http://localhost:4000`)
-)
+
+module.exports = server

--- a/yarn.lock
+++ b/yarn.lock
@@ -672,7 +672,7 @@ abbrev@1:
   version "1.1.1"
   resolved "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
 
-accepts@~1.3.5:
+accepts@~1.3.4, accepts@~1.3.5:
   version "1.3.5"
   resolved "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz#eb777df6011723a3b14e8a72c0805c8e86746bd2"
   dependencies:
@@ -1483,6 +1483,24 @@ commondir@^1.0.1:
 component-emitter@^1.2.1:
   version "1.2.1"
   resolved "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz#137918d6d78283f7df7a6b7c5a63e140e69425e6"
+
+compressible@~2.0.13:
+  version "2.0.13"
+  resolved "https://registry.npmjs.org/compressible/-/compressible-2.0.13.tgz#0d1020ab924b2fdb4d6279875c7d6daba6baa7a9"
+  dependencies:
+    mime-db ">= 1.33.0 < 2"
+
+compression@^1.7.2:
+  version "1.7.2"
+  resolved "http://registry.npmjs.org/compression/-/compression-1.7.2.tgz#aaffbcd6aaf854b44ebb280353d5ad1651f59a69"
+  dependencies:
+    accepts "~1.3.4"
+    bytes "3.0.0"
+    compressible "~2.0.13"
+    debug "2.6.9"
+    on-headers "~1.0.1"
+    safe-buffer "5.1.1"
+    vary "~1.1.2"
 
 concat-map@0.0.1:
   version "0.0.1"
@@ -3271,7 +3289,7 @@ miller-rabin@^4.0.0:
     bn.js "^4.0.0"
     brorand "^1.0.1"
 
-mime-db@~1.33.0:
+"mime-db@>= 1.33.0 < 2", mime-db@~1.33.0:
   version "1.33.0"
   resolved "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz#a3492050a5cb9b63450541e39d9788d2272783db"
 
@@ -3676,6 +3694,10 @@ on-finished@~2.3.0:
   resolved "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz#20f1336481b083cd75337992a16971aa2d906947"
   dependencies:
     ee-first "1.1.1"
+
+on-headers@~1.0.1:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz#928f5d0f470d49342651ea6794b0857c100693f7"
 
 once@^1.3.0, once@^1.3.1, once@^1.4.0:
   version "1.4.0"


### PR DESCRIPTION
This PR combines the `next.js` and `graphql-yoga` servers, so that you only have to execute one command to start the full stack.

`yarn run dev` instead of `yarn run server` `yarn run dev`